### PR TITLE
feat: enable pure Go tests without metal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS
+
+## Project Overview
+Go-Metal is a deep learning library for Go that targets Apple Silicon GPUs through Metal Performance Shaders (MPS/MPSGraph). The codebase is split into Go packages that mirror major subsystems of a training stack.
+
+## Repository Layout
+- `app/` – small demo applications that exercise the library
+- `async/` – asynchronous command buffers, staging pools, and dataloaders
+- `cgo_bridge/` – Objective-C bridge to Metal/MPSGraph (requires Apple's clang and Objective-C ARC)
+- `checkpoints/` – save and load model weights and training state
+- `docs/` – generated documentation (`task docs` regenerates package `docs.md` files)
+- `engine/` – tensor engine, autograd, execution helpers
+- `examples/` – stand‑alone examples referenced in the docs
+- `layers/` – neural network layer implementations
+- `memory/` – GPU memory management utilities
+- `optimizer/` – optimization algorithms (SGD, Adam, etc.)
+- `training/` – training session orchestration
+- `vision/` – computer vision helpers (datasets, preprocessing, dataloaders)
+- `Taskfile.yml` – common build/test/docs tasks
+- `enhancements.md` – roadmap and planned features
+
+## Development Workflow
+- macOS 12+ on Apple Silicon is required; Linux containers lack Metal/ARC support
+- Go 1.21 or newer
+- Install Xcode Command Line Tools for Apple's clang: `xcode-select --install`
+- Format Go code with `gofmt -w` (or `go fmt`) before committing
+- Run `go mod tidy` after modifying dependencies
+- Use `go vet` for basic static checks when available
+- Regenerate documentation after changing exported APIs: `task docs`
+- Commit generated `docs.md` files when they change
+
+## Testing
+- Tests that exercise the Metal bindings only run on macOS with Apple's clang and Objective‑C ARC
+- Run the full suite on macOS:
+  ```bash
+  CC=clang go test ./...
+  ```
+- In non-Metal environments you can still execute the pure-Go tests:
+  ```bash
+  CGO_ENABLED=0 go test ./checkpoints
+  ```
+- The `Taskfile` exposes `task test` which wraps the macOS run above
+- If Metal-dependent tests cannot be executed, note the missing dependencies in your PR description
+
+## Useful Commands
+- `task build` – build the module
+- `task test` – run tests with correct CGO flags (still requires macOS)
+- `task docs` – regenerate package documentation
+- `task clean` – remove Go build cache
+
+Follow these guidelines for all changes in this repository.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ Why did I build this? I wanted to increase my knowledge in Machine Learning, and
 - **Checkpointing**: Model saving and loading (ONNX format supported)
 - **Mixed Precision**: Float16 support for memory-efficient training
 
+## 📁 Repository Layout
+
+| Path | Description |
+|------|-------------|
+| app/ | Demo applications |
+| async/ | Asynchronous command buffers, staging pools, and dataloaders |
+| cgo_bridge/ | Objective-C bridge to Metal/MPSGraph (needs Apple clang and ARC) |
+| checkpoints/ | Model checkpoints and training state |
+| docs/ | Generated documentation (`task docs`) |
+| engine/ | Tensor engine, autograd, execution helpers |
+| examples/ | Stand-alone usage examples |
+| layers/ | Neural network layer implementations |
+| memory/ | GPU memory management utilities |
+| optimizer/ | Optimization algorithms |
+| training/ | Training loop orchestration |
+| vision/ | Vision datasets, preprocessing, dataloaders |
+| Taskfile.yml | Build/test/docs task definitions |
+| enhancements.md | Roadmap of planned features |
+
 ## 📋 Requirements
 
 - **Operating System**: macOS 12.0+ (Monterey or later)
@@ -785,10 +804,44 @@ Contributions are welcome.
    # This generates documentation (docs.md) in every directory in go-metal
    task docs
    ```
-3. Make your changes and ensure tests pass:
+3. Ensure you have Apple's Clang with Objective-C ARC support. On macOS this is included with the Xcode Command Line Tools:
    ```bash
-   go test ./...
+   xcode-select --install    # installs clang with ARC support
+   which clang               # verify clang is available
+   clang --version           # confirm it's Apple clang
    ```
+
+   Tests require this compiler and will fail on systems without ARC (e.g. Linux) with errors like `-fobjc-arc is not supported`.
+
+4. Format, vet, and test your changes:
+   ```bash
+   gofmt -w .                # or go fmt ./...
+   go vet ./...              # optional static checks
+   CC=clang go test ./...    # run tests with ARC enabled
+   ```
+
+   Alternatively, set `CC=clang` once and use the Taskfile:
+   ```bash
+   export CC=clang
+   task test
+   ```
+
+### Testing
+
+The full test suite exercises the Metal bindings and must be run with Apple's clang so Objective-C ARC is enabled. On macOS:
+
+```bash
+xcode-select --install    # once, installs clang with ARC support
+CC=clang go test ./...
+```
+
+In environments without ARC or Metal (e.g. this Linux container), you can still run the pure-Go tests:
+
+```bash
+CGO_ENABLED=0 go test ./checkpoints
+```
+
+If the Metal-dependent tests cannot be executed, document the missing dependencies in your PR.
 
 ### Areas for Contribution
 - More neural network layers (LSTM, Transformer blocks)

--- a/cgo_bridge/stub.go
+++ b/cgo_bridge/stub.go
@@ -1,0 +1,6 @@
+//go:build !darwin
+// +build !darwin
+
+package cgo_bridge
+
+// Stub implementations for non-Apple platforms to allow builds without Metal.

--- a/checkpoints/checkpoint.go
+++ b/checkpoints/checkpoint.go
@@ -1,3 +1,6 @@
+//go:build darwin
+// +build darwin
+
 package checkpoints
 
 import (
@@ -38,43 +41,43 @@ func (cf CheckpointFormat) String() string {
 // Checkpoint represents a complete model state including weights, optimizer state, and training metadata
 type Checkpoint struct {
 	// Model architecture and weights
-	ModelSpec   *layers.ModelSpec `json:"model_spec"`
-	Weights     []WeightTensor    `json:"weights"`
-	
+	ModelSpec *layers.ModelSpec `json:"model_spec"`
+	Weights   []WeightTensor    `json:"weights"`
+
 	// Training state
 	TrainingState TrainingState `json:"training_state"`
-	
+
 	// Optimizer state (if available)
 	OptimizerState *OptimizerState `json:"optimizer_state,omitempty"`
-	
+
 	// Metadata
 	Metadata CheckpointMetadata `json:"metadata"`
 }
 
 // WeightTensor represents a model parameter tensor with its data
 type WeightTensor struct {
-	Name   string    `json:"name"`
-	Shape  []int     `json:"shape"`
-	Data   []float32 `json:"data"`
-	Layer  string    `json:"layer"`
-	Type   string    `json:"type"` // "weight", "bias", "gamma", "beta", etc.
+	Name  string    `json:"name"`
+	Shape []int     `json:"shape"`
+	Data  []float32 `json:"data"`
+	Layer string    `json:"layer"`
+	Type  string    `json:"type"` // "weight", "bias", "gamma", "beta", etc.
 }
 
 // TrainingState captures the current training progress
 type TrainingState struct {
-	Epoch         int     `json:"epoch"`
-	Step          int     `json:"step"`
-	LearningRate  float32 `json:"learning_rate"`
-	BestLoss      float32 `json:"best_loss"`
-	BestAccuracy  float32 `json:"best_accuracy"`
-	TotalSteps    int     `json:"total_steps"`
+	Epoch        int     `json:"epoch"`
+	Step         int     `json:"step"`
+	LearningRate float32 `json:"learning_rate"`
+	BestLoss     float32 `json:"best_loss"`
+	BestAccuracy float32 `json:"best_accuracy"`
+	TotalSteps   int     `json:"total_steps"`
 }
 
 // OptimizerState captures optimizer-specific state (momentum, variance, etc.)
 type OptimizerState struct {
-	Type        string                 `json:"type"` // "SGD", "Adam", etc.
-	Parameters  map[string]interface{} `json:"parameters"`
-	StateData   []OptimizerTensor      `json:"state_data"`
+	Type       string                 `json:"type"` // "SGD", "Adam", etc.
+	Parameters map[string]interface{} `json:"parameters"`
+	StateData  []OptimizerTensor      `json:"state_data"`
 }
 
 // OptimizerTensor represents optimizer state tensors (momentum, variance, etc.)
@@ -138,20 +141,20 @@ func (cs *CheckpointSaver) saveJSON(checkpoint *Checkpoint, path string) error {
 		checkpoint.Metadata.Version = "1.0.0"
 		checkpoint.Metadata.CreatedAt = time.Now()
 	}
-	
+
 	file, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create checkpoint file: %v", err)
 	}
 	defer file.Close()
-	
+
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ") // Pretty print JSON
-	
+
 	if err := encoder.Encode(checkpoint); err != nil {
 		return fmt.Errorf("failed to encode checkpoint: %v", err)
 	}
-	
+
 	return nil
 }
 
@@ -162,14 +165,14 @@ func (cs *CheckpointSaver) loadJSON(path string) (*Checkpoint, error) {
 		return nil, fmt.Errorf("failed to open checkpoint file: %v", err)
 	}
 	defer file.Close()
-	
+
 	var checkpoint Checkpoint
 	decoder := json.NewDecoder(file)
-	
+
 	if err := decoder.Decode(&checkpoint); err != nil {
 		return nil, fmt.Errorf("failed to decode checkpoint: %v", err)
 	}
-	
+
 	// CRITICAL FIX: JSON models often lack BatchNorm running statistics
 	// ONNX models include them, but JSON models use defaults (mean=0, var=1)
 	// This causes identical predictions for all images
@@ -177,7 +180,7 @@ func (cs *CheckpointSaver) loadJSON(path string) (*Checkpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to ensure BatchNorm statistics: %v", err)
 	}
-	
+
 	return &checkpoint, nil
 }
 
@@ -196,26 +199,26 @@ func (cs *CheckpointSaver) loadONNX(path string) (*Checkpoint, error) {
 // ExtractWeightsFromTensors extracts weight data from GPU tensors while maintaining GPU-resident design
 func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.ModelSpec) ([]WeightTensor, error) {
 	var weights []WeightTensor
-	
+
 	// Map parameter tensors to their corresponding layers and types
 	paramIndex := 0
 	for layerIdx, layerSpec := range modelSpec.Layers {
 		layerName := layerSpec.Name
-		
+
 		switch layerSpec.Type {
 		case layers.Dense:
 			// Dense layer: weight + optional bias
 			if paramIndex >= len(tensors) {
 				return nil, fmt.Errorf("insufficient tensors for dense layer %s", layerName)
 			}
-			
+
 			// Weight tensor
 			weightTensor := tensors[paramIndex]
 			weightData, err := weightTensor.ToFloat32Slice()
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract weight data for layer %s: %v", layerName, err)
 			}
-			
+
 			weights = append(weights, WeightTensor{
 				Name:  fmt.Sprintf("%s.weight", layerName),
 				Shape: weightTensor.Shape(),
@@ -224,20 +227,20 @@ func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.Model
 				Type:  "weight",
 			})
 			paramIndex++
-			
+
 			// Bias tensor (if present)
 			useBias := layerSpec.Parameters["use_bias"].(bool)
 			if useBias {
 				if paramIndex >= len(tensors) {
 					return nil, fmt.Errorf("insufficient tensors for dense layer bias %s", layerName)
 				}
-				
+
 				biasTensor := tensors[paramIndex]
 				biasData, err := biasTensor.ToFloat32Slice()
 				if err != nil {
 					return nil, fmt.Errorf("failed to extract bias data for layer %s: %v", layerName, err)
 				}
-				
+
 				weights = append(weights, WeightTensor{
 					Name:  fmt.Sprintf("%s.bias", layerName),
 					Shape: biasTensor.Shape(),
@@ -247,20 +250,20 @@ func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.Model
 				})
 				paramIndex++
 			}
-			
+
 		case layers.Conv2D:
 			// Conv2D layer: weight + optional bias
 			if paramIndex >= len(tensors) {
 				return nil, fmt.Errorf("insufficient tensors for conv2d layer %s", layerName)
 			}
-			
+
 			// Weight tensor
 			weightTensor := tensors[paramIndex]
 			weightData, err := weightTensor.ToFloat32Slice()
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract weight data for layer %s: %v", layerName, err)
 			}
-			
+
 			weights = append(weights, WeightTensor{
 				Name:  fmt.Sprintf("%s.weight", layerName),
 				Shape: weightTensor.Shape(),
@@ -269,20 +272,20 @@ func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.Model
 				Type:  "weight",
 			})
 			paramIndex++
-			
+
 			// Bias tensor (if present)
 			useBias := layerSpec.Parameters["use_bias"].(bool)
 			if useBias {
 				if paramIndex >= len(tensors) {
 					return nil, fmt.Errorf("insufficient tensors for conv2d layer bias %s", layerName)
 				}
-				
+
 				biasTensor := tensors[paramIndex]
 				biasData, err := biasTensor.ToFloat32Slice()
 				if err != nil {
 					return nil, fmt.Errorf("failed to extract bias data for layer %s: %v", layerName, err)
 				}
-				
+
 				weights = append(weights, WeightTensor{
 					Name:  fmt.Sprintf("%s.bias", layerName),
 					Shape: biasTensor.Shape(),
@@ -292,7 +295,7 @@ func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.Model
 				})
 				paramIndex++
 			}
-			
+
 		case layers.BatchNorm:
 			// BatchNorm layer: gamma + beta (if affine=true)
 			affine := layerSpec.Parameters["affine"].(bool)
@@ -300,14 +303,14 @@ func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.Model
 				if paramIndex+1 >= len(tensors) {
 					return nil, fmt.Errorf("insufficient tensors for batchnorm layer %s", layerName)
 				}
-				
+
 				// Gamma (scale) tensor
 				gammaTensor := tensors[paramIndex]
 				gammaData, err := gammaTensor.ToFloat32Slice()
 				if err != nil {
 					return nil, fmt.Errorf("failed to extract gamma data for layer %s: %v", layerName, err)
 				}
-				
+
 				weights = append(weights, WeightTensor{
 					Name:  fmt.Sprintf("%s.weight", layerName), // ONNX uses "weight" for gamma
 					Shape: gammaTensor.Shape(),
@@ -316,14 +319,14 @@ func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.Model
 					Type:  "gamma",
 				})
 				paramIndex++
-				
+
 				// Beta (shift) tensor
 				betaTensor := tensors[paramIndex]
 				betaData, err := betaTensor.ToFloat32Slice()
 				if err != nil {
 					return nil, fmt.Errorf("failed to extract beta data for layer %s: %v", layerName, err)
 				}
-				
+
 				weights = append(weights, WeightTensor{
 					Name:  fmt.Sprintf("%s.bias", layerName), // ONNX uses "bias" for beta
 					Shape: betaTensor.Shape(),
@@ -333,18 +336,18 @@ func ExtractWeightsFromTensors(tensors []*memory.Tensor, modelSpec *layers.Model
 				})
 				paramIndex++
 			}
-			
+
 		case layers.ReLU, layers.LeakyReLU, layers.Softmax, layers.Dropout, layers.Sigmoid:
 			// Activation layers have no parameters
 			continue
-			
+
 		default:
 			return nil, fmt.Errorf("unsupported layer type for weight extraction: %s", layerSpec.Type.String())
 		}
-		
+
 		_ = layerIdx // Suppress unused variable warning
 	}
-	
+
 	return weights, nil
 }
 
@@ -354,7 +357,7 @@ func LoadWeightsIntoTensors(weights []WeightTensor, tensors []*memory.Tensor) er
 	// Running statistics are handled separately by the inference execution engine
 	learnableWeights := make([]WeightTensor, 0, len(weights))
 	runningStatsWeights := make([]WeightTensor, 0)
-	
+
 	for _, weight := range weights {
 		if weight.Type == "running_mean" || weight.Type == "running_var" {
 			runningStatsWeights = append(runningStatsWeights, weight)
@@ -363,51 +366,51 @@ func LoadWeightsIntoTensors(weights []WeightTensor, tensors []*memory.Tensor) er
 			learnableWeights = append(learnableWeights, weight)
 		}
 	}
-	
+
 	// DEBUG removed: Weight loading progress
-	
+
 	// Create a map for quick weight lookup
 	weightMap := make(map[string]WeightTensor)
 	for _, weight := range learnableWeights {
 		weightMap[weight.Name] = weight
 	}
-	
+
 	// We need to match tensors with weights based on the layer naming convention
 	// This is a simplified implementation that assumes tensors are in the same order
 	// as they were extracted (but now only counting learnable parameters)
 	if len(learnableWeights) != len(tensors) {
 		return fmt.Errorf("weight count mismatch: %d weights, %d tensors", len(learnableWeights), len(tensors))
 	}
-	
+
 	for i, tensor := range tensors {
 		if i >= len(learnableWeights) {
 			break
 		}
-		
+
 		weight := learnableWeights[i]
-		
+
 		// Verify tensor and weight compatibility
 		tensorShape := tensor.Shape()
-		
+
 		// Verify tensor and weight compatibility
 		if len(tensorShape) != len(weight.Shape) {
-			return fmt.Errorf("shape mismatch for weight %s: tensor %v vs weight %v", 
+			return fmt.Errorf("shape mismatch for weight %s: tensor %v vs weight %v",
 				weight.Name, tensorShape, weight.Shape)
 		}
-		
+
 		for j, dim := range tensorShape {
 			if dim != weight.Shape[j] {
-				return fmt.Errorf("dimension mismatch for weight %s at index %d: tensor %d vs weight %d", 
+				return fmt.Errorf("dimension mismatch for weight %s at index %d: tensor %d vs weight %d",
 					weight.Name, j, dim, weight.Shape[j])
 			}
 		}
-		
+
 		// Copy weight data into tensor
 		if err := tensor.CopyFloat32Data(weight.Data); err != nil {
 			return fmt.Errorf("failed to copy weight data for %s: %v", weight.Name, err)
 		}
 	}
-	
+
 	return nil
 }
 
@@ -423,11 +426,11 @@ func ensureBatchNormStatistics(checkpoint *Checkpoint) error {
 			batchNormLayers[layer.Name] = layer
 		}
 	}
-	
+
 	if len(batchNormLayers) == 0 {
 		return nil // No BatchNorm layers, nothing to fix
 	}
-	
+
 	// Check which BatchNorm layers are missing running statistics
 	existingStats := make(map[string]bool)
 	for _, weight := range checkpoint.Weights {
@@ -435,15 +438,15 @@ func ensureBatchNormStatistics(checkpoint *Checkpoint) error {
 			existingStats[weight.Layer] = true
 		}
 	}
-	
+
 	var addedCount int
-	
+
 	// Generate missing running statistics for each BatchNorm layer
 	for layerName, layerSpec := range batchNormLayers {
 		if existingStats[layerName] {
 			continue // This layer already has running statistics
 		}
-		
+
 		// Extract num_features from layer parameters
 		numFeatures, ok := layerSpec.Parameters["num_features"].(int)
 		if !ok {
@@ -455,15 +458,15 @@ func ensureBatchNormStatistics(checkpoint *Checkpoint) error {
 				continue
 			}
 		}
-		
+
 		if numFeatures <= 0 {
 			fmt.Printf("Warning: Invalid num_features (%d) for BatchNorm layer %s, skipping\n", numFeatures, layerName)
 			continue
 		}
-		
+
 		// Generate improved running statistics based on layer position and characteristics
-		runningMean, runningVar := generateIntelligentRunningStats(layerName, numFeatures, layerSpec)
-		
+		runningMean, runningVar := generateIntelligentRunningStats(layerName, numFeatures, layerSpec.RunningStatistics)
+
 		// Create running_mean tensor
 		meanTensor := WeightTensor{
 			Name:  fmt.Sprintf("%s.running_mean", layerName),
@@ -472,8 +475,8 @@ func ensureBatchNormStatistics(checkpoint *Checkpoint) error {
 			Layer: layerName,
 			Type:  "running_mean",
 		}
-		
-		// Create running_var tensor  
+
+		// Create running_var tensor
 		varTensor := WeightTensor{
 			Name:  fmt.Sprintf("%s.running_var", layerName),
 			Shape: []int{numFeatures},
@@ -481,61 +484,23 @@ func ensureBatchNormStatistics(checkpoint *Checkpoint) error {
 			Layer: layerName,
 			Type:  "running_var",
 		}
-		
+
 		// Add to checkpoint weights
 		checkpoint.Weights = append(checkpoint.Weights, meanTensor, varTensor)
-		
+
 		// Also add to layer specification for direct access during inference
 		if layerSpec.RunningStatistics == nil {
 			layerSpec.RunningStatistics = make(map[string][]float32)
 		}
 		layerSpec.RunningStatistics["running_mean"] = runningMean
 		layerSpec.RunningStatistics["running_var"] = runningVar
-		
+
 		addedCount += 2
 	}
-	
+
 	if addedCount > 0 {
 		fmt.Printf("✅ Generated %d missing BatchNorm running statistics for JSON model\n", addedCount)
 	}
-	
-	return nil
-}
 
-// generateIntelligentRunningStats creates reasonable running statistics for BatchNorm layers
-// This provides much better defaults than the standard mean=0, var=1
-func generateIntelligentRunningStats(layerName string, numFeatures int, layerSpec *layers.LayerSpec) ([]float32, []float32) {
-	runningMean := make([]float32, numFeatures)
-	runningVar := make([]float32, numFeatures)
-	
-	// CRITICAL FIX: Check if the layer already has running statistics stored
-	// This happens when the model was trained and the statistics were saved
-	if layerSpec.RunningStatistics != nil {
-		if existingMean, hasMean := layerSpec.RunningStatistics["running_mean"]; hasMean && len(existingMean) == numFeatures {
-			copy(runningMean, existingMean)
-		} else {
-			// Default mean = 0
-			for i := 0; i < numFeatures; i++ {
-				runningMean[i] = 0.0
-			}
-		}
-		
-		if existingVar, hasVar := layerSpec.RunningStatistics["running_var"]; hasVar && len(existingVar) == numFeatures {
-			copy(runningVar, existingVar)
-		} else {
-			// Default variance = 1
-			for i := 0; i < numFeatures; i++ {
-				runningVar[i] = 1.0
-			}
-		}
-	} else {
-		// No existing statistics - use defaults
-		// ONNX standard defaults: mean=0, var=1
-		for i := 0; i < numFeatures; i++ {
-			runningMean[i] = 0.0
-			runningVar[i] = 1.0
-		}
-	}
-	
-	return runningMean, runningVar
+	return nil
 }

--- a/checkpoints/checkpoint_test.go
+++ b/checkpoints/checkpoint_test.go
@@ -1,3 +1,6 @@
+//go:build darwin
+// +build darwin
+
 package checkpoints
 
 import (
@@ -16,13 +19,13 @@ func TestCheckpointJSONSaveLoad(t *testing.T) {
 	// Create a simple model spec for testing
 	inputShape := []int{1, 28, 28, 1} // MNIST-like shape
 	builder := layers.NewModelBuilder(inputShape)
-	
+
 	model, err := builder.
 		AddDense(128, true, "dense1").
 		AddReLU("relu1").
 		AddDense(10, true, "output").
 		Compile()
-	
+
 	if err != nil {
 		t.Fatalf("Failed to create test model: %v", err)
 	}
@@ -74,10 +77,10 @@ func TestCheckpointJSONSaveLoad(t *testing.T) {
 	// Test JSON save
 	saver := NewCheckpointSaver(FormatJSON)
 	testFile := "test_checkpoint.json"
-	
+
 	// Clean up
 	defer os.Remove(testFile)
-	
+
 	err = saver.SaveCheckpoint(checkpoint, testFile)
 	if err != nil {
 		t.Fatalf("Failed to save JSON checkpoint: %v", err)
@@ -91,12 +94,12 @@ func TestCheckpointJSONSaveLoad(t *testing.T) {
 
 	// Verify loaded data
 	if loadedCheckpoint.TrainingState.Epoch != checkpoint.TrainingState.Epoch {
-		t.Errorf("Epoch mismatch: expected %d, got %d", 
+		t.Errorf("Epoch mismatch: expected %d, got %d",
 			checkpoint.TrainingState.Epoch, loadedCheckpoint.TrainingState.Epoch)
 	}
 
 	if len(loadedCheckpoint.Weights) != len(checkpoint.Weights) {
-		t.Errorf("Weight count mismatch: expected %d, got %d", 
+		t.Errorf("Weight count mismatch: expected %d, got %d",
 			len(checkpoint.Weights), len(loadedCheckpoint.Weights))
 	}
 
@@ -104,21 +107,21 @@ func TestCheckpointJSONSaveLoad(t *testing.T) {
 	if len(loadedCheckpoint.Weights) > 0 {
 		originalWeight := checkpoint.Weights[0]
 		loadedWeight := loadedCheckpoint.Weights[0]
-		
+
 		if originalWeight.Name != loadedWeight.Name {
-			t.Errorf("Weight name mismatch: expected %s, got %s", 
+			t.Errorf("Weight name mismatch: expected %s, got %s",
 				originalWeight.Name, loadedWeight.Name)
 		}
-		
+
 		if len(originalWeight.Data) != len(loadedWeight.Data) {
-			t.Errorf("Weight data length mismatch: expected %d, got %d", 
+			t.Errorf("Weight data length mismatch: expected %d, got %d",
 				len(originalWeight.Data), len(loadedWeight.Data))
 		}
-		
+
 		// Check first few values
 		for i := 0; i < 10 && i < len(originalWeight.Data); i++ {
 			if originalWeight.Data[i] != loadedWeight.Data[i] {
-				t.Errorf("Weight data mismatch at index %d: expected %f, got %f", 
+				t.Errorf("Weight data mismatch at index %d: expected %f, got %f",
 					i, originalWeight.Data[i], loadedWeight.Data[i])
 			}
 		}
@@ -131,13 +134,13 @@ func TestCheckpointONNXExport(t *testing.T) {
 	// Create a simple model spec for testing
 	inputShape := []int{1, 28, 28, 1} // MNIST-like shape
 	builder := layers.NewModelBuilder(inputShape)
-	
+
 	model, err := builder.
 		AddDense(64, true, "dense1").
 		AddReLU("relu1").
 		AddDense(10, true, "output").
 		Compile()
-	
+
 	if err != nil {
 		t.Fatalf("Failed to create test model: %v", err)
 	}
@@ -179,10 +182,10 @@ func TestCheckpointONNXExport(t *testing.T) {
 	// Test ONNX export
 	saver := NewCheckpointSaver(FormatONNX)
 	testFile := "test_model.onnx"
-	
+
 	// Clean up
 	defer os.Remove(testFile)
-	
+
 	err = saver.SaveCheckpoint(checkpoint, testFile)
 	if err != nil {
 		t.Fatalf("Failed to export ONNX model: %v", err)
@@ -302,7 +305,7 @@ func TestJSONLoadFileErrors(t *testing.T) {
 	// Test loading invalid JSON file
 	invalidJSONFile := "invalid.json"
 	defer os.Remove(invalidJSONFile)
-	
+
 	if err := os.WriteFile(invalidJSONFile, []byte("{invalid json"), 0644); err != nil {
 		t.Fatalf("Failed to create invalid JSON file: %v", err)
 	}
@@ -351,7 +354,7 @@ func TestJSONSaveFileErrors(t *testing.T) {
 // TestCheckpointMetadataDefaults tests automatic metadata setting
 func TestCheckpointMetadataDefaults(t *testing.T) {
 	saver := NewCheckpointSaver(FormatJSON)
-	
+
 	// Create checkpoint with minimal metadata
 	inputShape := []int{1, 10}
 	builder := layers.NewModelBuilder(inputShape)
@@ -369,7 +372,7 @@ func TestCheckpointMetadataDefaults(t *testing.T) {
 	// Save checkpoint
 	testFile := "test_metadata.json"
 	defer os.Remove(testFile)
-	
+
 	err = saver.SaveCheckpoint(checkpoint, testFile)
 	if err != nil {
 		t.Fatalf("Failed to save checkpoint: %v", err)
@@ -494,19 +497,19 @@ func (mt *MockTensor) Release() {
 func TestExtractWeightsFromTensors(t *testing.T) {
 	// Since we can't easily create real memory.Tensor objects for testing,
 	// let's test the error conditions and validation logic
-	
+
 	// Test with nil tensors and model - this will panic in the actual function
 	// so we need to skip this test case and focus on testing with valid models
 
 	// Create a test model with Dense layers
 	inputShape := []int{1, 32}
 	builder := layers.NewModelBuilder(inputShape)
-	
+
 	model, err := builder.
-		AddDense(16, true, "dense1").  // Dense with bias
-		AddDense(8, false, "dense2").  // Dense without bias
+		AddDense(16, true, "dense1"). // Dense with bias
+		AddDense(8, false, "dense2"). // Dense without bias
 		Compile()
-	
+
 	if err != nil {
 		t.Fatalf("Failed to create test model: %v", err)
 	}
@@ -609,12 +612,12 @@ func TestLoadWeightsIntoTensors(t *testing.T) {
 
 // Helper function to verify contains functionality
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && 
-		   (s == substr || 
-		    (len(s) > len(substr) && 
-		     (s[:len(substr)] == substr || 
-		      s[len(s)-len(substr):] == substr || 
-		      containsAtIndex(s, substr))))
+	return len(s) >= len(substr) &&
+		(s == substr ||
+			(len(s) > len(substr) &&
+				(s[:len(substr)] == substr ||
+					s[len(s)-len(substr):] == substr ||
+					containsAtIndex(s, substr))))
 }
 
 func containsAtIndex(s, substr string) bool {
@@ -667,7 +670,7 @@ func TestONNXImportFileErrors(t *testing.T) {
 	// Test importing invalid protobuf file
 	invalidFile := "invalid.onnx"
 	defer os.Remove(invalidFile)
-	
+
 	if err := os.WriteFile(invalidFile, []byte("invalid protobuf data"), 0644); err != nil {
 		t.Fatalf("Failed to create invalid protobuf file: %v", err)
 	}
@@ -718,7 +721,7 @@ func TestONNXFormatHandling(t *testing.T) {
 		},
 	}
 
-	// Test ONNX format handling 
+	// Test ONNX format handling
 	onnxSaver := NewCheckpointSaver(FormatONNX)
 	if onnxSaver.format != FormatONNX {
 		t.Errorf("Expected ONNX format, got %d", onnxSaver.format)
@@ -727,7 +730,7 @@ func TestONNXFormatHandling(t *testing.T) {
 	// Test ONNX save operation (should attempt to create ONNX file)
 	onnxFile := "test_format.onnx"
 	defer os.Remove(onnxFile)
-	
+
 	err = onnxSaver.SaveCheckpoint(checkpoint, onnxFile)
 	// This may fail due to protobuf generation, but should not panic
 	if err != nil {
@@ -777,7 +780,7 @@ func TestMemoryManagerMocking(t *testing.T) {
 func TestWeightTensorValidation(t *testing.T) {
 	// Test different weight types
 	tests := []struct {
-		weight WeightTensor
+		weight         WeightTensor
 		isRunningStats bool
 	}{
 		{
@@ -809,7 +812,7 @@ func TestWeightTensorValidation(t *testing.T) {
 	for _, test := range tests {
 		isRunning := test.weight.Type == "running_mean" || test.weight.Type == "running_var"
 		if isRunning != test.isRunningStats {
-			t.Errorf("Weight type %s: expected running stats %t, got %t", 
+			t.Errorf("Weight type %s: expected running stats %t, got %t",
 				test.weight.Type, test.isRunningStats, isRunning)
 		}
 	}
@@ -866,7 +869,7 @@ func TestCompleteCheckpointRoundTrip(t *testing.T) {
 	// Initialize weights with pattern data for verification
 	for i, weight := range weights {
 		for j := range weight.Data {
-			weights[i].Data[j] = float32(i*100 + j) * 0.01
+			weights[i].Data[j] = float32(i*100+j) * 0.01
 		}
 	}
 
@@ -920,17 +923,17 @@ func TestCompleteCheckpointRoundTrip(t *testing.T) {
 
 	// Verify round-trip integrity
 	if loaded.TrainingState.Epoch != original.TrainingState.Epoch {
-		t.Errorf("Training state epoch mismatch: expected %d, got %d", 
+		t.Errorf("Training state epoch mismatch: expected %d, got %d",
 			original.TrainingState.Epoch, loaded.TrainingState.Epoch)
 	}
 
 	if loaded.TrainingState.LearningRate != original.TrainingState.LearningRate {
-		t.Errorf("Learning rate mismatch: expected %f, got %f", 
+		t.Errorf("Learning rate mismatch: expected %f, got %f",
 			original.TrainingState.LearningRate, loaded.TrainingState.LearningRate)
 	}
 
 	if len(loaded.Weights) != len(original.Weights) {
-		t.Errorf("Weight count mismatch: expected %d, got %d", 
+		t.Errorf("Weight count mismatch: expected %d, got %d",
 			len(original.Weights), len(loaded.Weights))
 	}
 
@@ -943,12 +946,12 @@ func TestCompleteCheckpointRoundTrip(t *testing.T) {
 
 		loadedWeight := loaded.Weights[i]
 		if originalWeight.Name != loadedWeight.Name {
-			t.Errorf("Weight %d name mismatch: expected %s, got %s", 
+			t.Errorf("Weight %d name mismatch: expected %s, got %s",
 				i, originalWeight.Name, loadedWeight.Name)
 		}
 
 		if len(originalWeight.Data) != len(loadedWeight.Data) {
-			t.Errorf("Weight %d data length mismatch: expected %d, got %d", 
+			t.Errorf("Weight %d data length mismatch: expected %d, got %d",
 				i, len(originalWeight.Data), len(loadedWeight.Data))
 			continue
 		}
@@ -956,7 +959,7 @@ func TestCompleteCheckpointRoundTrip(t *testing.T) {
 		// Check data values
 		for j, originalVal := range originalWeight.Data {
 			if j < len(loadedWeight.Data) && originalVal != loadedWeight.Data[j] {
-				t.Errorf("Weight %d data[%d] mismatch: expected %f, got %f", 
+				t.Errorf("Weight %d data[%d] mismatch: expected %f, got %f",
 					i, j, originalVal, loadedWeight.Data[j])
 				break // Only report first mismatch
 			}
@@ -968,19 +971,19 @@ func TestCompleteCheckpointRoundTrip(t *testing.T) {
 		t.Error("Loaded checkpoint missing optimizer state")
 	} else {
 		if loaded.OptimizerState.Type != original.OptimizerState.Type {
-			t.Errorf("Optimizer type mismatch: expected %s, got %s", 
+			t.Errorf("Optimizer type mismatch: expected %s, got %s",
 				original.OptimizerState.Type, loaded.OptimizerState.Type)
 		}
 	}
 
 	// Verify metadata
 	if loaded.Metadata.Framework != original.Metadata.Framework {
-		t.Errorf("Framework mismatch: expected %s, got %s", 
+		t.Errorf("Framework mismatch: expected %s, got %s",
 			original.Metadata.Framework, loaded.Metadata.Framework)
 	}
 
 	if len(loaded.Metadata.Tags) != len(original.Metadata.Tags) {
-		t.Errorf("Tags count mismatch: expected %d, got %d", 
+		t.Errorf("Tags count mismatch: expected %d, got %d",
 			len(original.Metadata.Tags), len(loaded.Metadata.Tags))
 	}
 

--- a/checkpoints/onnx.go
+++ b/checkpoints/onnx.go
@@ -1,3 +1,6 @@
+//go:build darwin
+// +build darwin
+
 package checkpoints
 
 import (
@@ -23,33 +26,33 @@ func NewONNXExporter() *ONNXExporter {
 func (oe *ONNXExporter) ExportToONNX(checkpoint *Checkpoint, path string) error {
 	// Create ONNX model proto
 	model := &ModelProto{
-		IrVersion:      7, // ONNX IR version 7
-		OpsetImport:    []*OperatorSetIdProto{{Domain: "", Version: 13}}, // Opset 13
-		ProducerName:   "go-metal",
+		IrVersion:       7,                                                // ONNX IR version 7
+		OpsetImport:     []*OperatorSetIdProto{{Domain: "", Version: 13}}, // Opset 13
+		ProducerName:    "go-metal",
 		ProducerVersion: "1.0.0",
-		ModelVersion:   1,
+		ModelVersion:    1,
 	}
-	
+
 	// Create the computation graph
 	graph, err := oe.buildONNXGraph(checkpoint)
 	if err != nil {
 		return fmt.Errorf("failed to build ONNX graph: %v", err)
 	}
-	
+
 	model.Graph = graph
 	oe.model = model
-	
+
 	// Serialize to protobuf
 	data, err := proto.Marshal(model)
 	if err != nil {
 		return fmt.Errorf("failed to marshal ONNX model: %v", err)
 	}
-	
+
 	// Write to file
 	if err := os.WriteFile(path, data, 0644); err != nil {
 		return fmt.Errorf("failed to write ONNX file: %v", err)
 	}
-	
+
 	return nil
 }
 
@@ -58,16 +61,16 @@ func (oe *ONNXExporter) buildONNXGraph(checkpoint *Checkpoint) (*GraphProto, err
 	graph := &GraphProto{
 		Name: "go-metal-model",
 	}
-	
+
 	// Create weight map for easy lookup
 	weightMap := make(map[string]WeightTensor)
 	for _, weight := range checkpoint.Weights {
 		weightMap[weight.Name] = weight
 	}
-	
+
 	// Track tensor names for graph connectivity
 	var currentTensorName string = "input"
-	
+
 	// Add input tensor
 	inputShape := checkpoint.ModelSpec.InputShape
 	inputInfo := &ValueInfoProto{
@@ -84,13 +87,13 @@ func (oe *ONNXExporter) buildONNXGraph(checkpoint *Checkpoint) (*GraphProto, err
 		},
 	}
 	graph.Input = append(graph.Input, inputInfo)
-	
+
 	// Process each layer and create corresponding ONNX nodes
 	for layerIdx, layerSpec := range checkpoint.ModelSpec.Layers {
 		var nodes []*NodeProto
 		var initializers []*TensorProto
 		var err error
-		
+
 		switch layerSpec.Type {
 		case layers.Conv2D:
 			nodes, initializers, currentTensorName, err = oe.createConv2DNode(layerSpec, weightMap, currentTensorName, layerIdx)
@@ -115,16 +118,16 @@ func (oe *ONNXExporter) buildONNXGraph(checkpoint *Checkpoint) (*GraphProto, err
 		default:
 			return nil, fmt.Errorf("unsupported layer type for ONNX export: %s", layerSpec.Type.String())
 		}
-		
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to create ONNX node for layer %s: %v", layerSpec.Name, err)
 		}
-		
+
 		// Add nodes and initializers to graph
 		graph.Node = append(graph.Node, nodes...)
 		graph.Initializer = append(graph.Initializer, initializers...)
 	}
-	
+
 	// Add output tensor
 	outputShape := checkpoint.ModelSpec.OutputShape
 	outputInfo := &ValueInfoProto{
@@ -141,7 +144,7 @@ func (oe *ONNXExporter) buildONNXGraph(checkpoint *Checkpoint) (*GraphProto, err
 		},
 	}
 	graph.Output = append(graph.Output, outputInfo)
-	
+
 	return graph, nil
 }
 
@@ -149,13 +152,13 @@ func (oe *ONNXExporter) buildONNXGraph(checkpoint *Checkpoint) (*GraphProto, err
 func (oe *ONNXExporter) createConv2DNode(layerSpec layers.LayerSpec, weightMap map[string]WeightTensor, inputTensor string, layerIdx int) ([]*NodeProto, []*TensorProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	// Get layer parameters
 	kernelSize := layerSpec.Parameters["kernel_size"].(int)
 	stride := layerSpec.Parameters["stride"].(int)
 	padding := layerSpec.Parameters["padding"].(int)
 	useBias := layerSpec.Parameters["use_bias"].(bool)
-	
+
 	// Create Conv node
 	convNode := &NodeProto{
 		OpType: "Conv",
@@ -168,25 +171,25 @@ func (oe *ONNXExporter) createConv2DNode(layerSpec layers.LayerSpec, weightMap m
 			{Name: "pads", Ints: []int64{int64(padding), int64(padding), int64(padding), int64(padding)}},
 		},
 	}
-	
+
 	// Add bias if present
 	if useBias {
 		convNode.Input = append(convNode.Input, fmt.Sprintf("%s.bias", layerName))
 	}
-	
+
 	// Create weight initializer
 	var initializers []*TensorProto
 	weightTensor := weightMap[fmt.Sprintf("%s.weight", layerName)]
 	weightInit := oe.createTensorProto(fmt.Sprintf("%s.weight", layerName), weightTensor.Shape, weightTensor.Data)
 	initializers = append(initializers, weightInit)
-	
+
 	// Create bias initializer if present
 	if useBias {
 		biasTensor := weightMap[fmt.Sprintf("%s.bias", layerName)]
 		biasInit := oe.createTensorProto(fmt.Sprintf("%s.bias", layerName), biasTensor.Shape, biasTensor.Data)
 		initializers = append(initializers, biasInit)
 	}
-	
+
 	return []*NodeProto{convNode}, initializers, outputTensor, nil
 }
 
@@ -195,9 +198,9 @@ func (oe *ONNXExporter) createDenseNode(layerSpec layers.LayerSpec, weightMap ma
 	layerName := layerSpec.Name
 	matmulOutput := fmt.Sprintf("%s_matmul", layerName)
 	finalOutput := fmt.Sprintf("%s_output", layerName)
-	
+
 	useBias := layerSpec.Parameters["use_bias"].(bool)
-	
+
 	// Create MatMul node
 	matmulNode := &NodeProto{
 		OpType: "MatMul",
@@ -205,28 +208,28 @@ func (oe *ONNXExporter) createDenseNode(layerSpec layers.LayerSpec, weightMap ma
 		Input:  []string{inputTensor, fmt.Sprintf("%s.weight", layerName)},
 		Output: []string{matmulOutput},
 	}
-	
+
 	var nodes []*NodeProto
 	nodes = append(nodes, matmulNode)
-	
+
 	// Create initializers
 	var initializers []*TensorProto
 	weightTensor := weightMap[fmt.Sprintf("%s.weight", layerName)]
-	
+
 	// Transpose weight matrix for ONNX (go-metal uses [input, output], ONNX expects [output, input])
 	transposedWeight := oe.transposeMatrix(weightTensor.Data, weightTensor.Shape)
 	transposedShape := []int{weightTensor.Shape[1], weightTensor.Shape[0]}
 	weightInit := oe.createTensorProto(fmt.Sprintf("%s.weight", layerName), transposedShape, transposedWeight)
 	initializers = append(initializers, weightInit)
-	
+
 	outputTensor := matmulOutput
-	
+
 	// Add bias if present
 	if useBias {
 		biasTensor := weightMap[fmt.Sprintf("%s.bias", layerName)]
 		biasInit := oe.createTensorProto(fmt.Sprintf("%s.bias", layerName), biasTensor.Shape, biasTensor.Data)
 		initializers = append(initializers, biasInit)
-		
+
 		// Create Add node for bias
 		addNode := &NodeProto{
 			OpType: "Add",
@@ -237,7 +240,7 @@ func (oe *ONNXExporter) createDenseNode(layerSpec layers.LayerSpec, weightMap ma
 		nodes = append(nodes, addNode)
 		outputTensor = finalOutput
 	}
-	
+
 	return nodes, initializers, outputTensor, nil
 }
 
@@ -245,14 +248,14 @@ func (oe *ONNXExporter) createDenseNode(layerSpec layers.LayerSpec, weightMap ma
 func (oe *ONNXExporter) createReLUNode(layerSpec layers.LayerSpec, inputTensor string, layerIdx int) ([]*NodeProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	reluNode := &NodeProto{
 		OpType: "Relu",
 		Name:   layerName,
 		Input:  []string{inputTensor},
 		Output: []string{outputTensor},
 	}
-	
+
 	return []*NodeProto{reluNode}, outputTensor, nil
 }
 
@@ -260,9 +263,9 @@ func (oe *ONNXExporter) createReLUNode(layerSpec layers.LayerSpec, inputTensor s
 func (oe *ONNXExporter) createLeakyReLUNode(layerSpec layers.LayerSpec, inputTensor string, layerIdx int) ([]*NodeProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	negativeSlope := layerSpec.Parameters["negative_slope"].(float32)
-	
+
 	leakyReluNode := &NodeProto{
 		OpType: "LeakyRelu",
 		Name:   layerName,
@@ -272,7 +275,7 @@ func (oe *ONNXExporter) createLeakyReLUNode(layerSpec layers.LayerSpec, inputTen
 			{Name: "alpha", F: negativeSlope},
 		},
 	}
-	
+
 	return []*NodeProto{leakyReluNode}, outputTensor, nil
 }
 
@@ -280,14 +283,14 @@ func (oe *ONNXExporter) createLeakyReLUNode(layerSpec layers.LayerSpec, inputTen
 func (oe *ONNXExporter) createSigmoidNode(layerSpec layers.LayerSpec, inputTensor string, layerIdx int) ([]*NodeProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	sigmoidNode := &NodeProto{
 		OpType: "Sigmoid",
 		Name:   layerName,
 		Input:  []string{inputTensor},
 		Output: []string{outputTensor},
 	}
-	
+
 	return []*NodeProto{sigmoidNode}, outputTensor, nil
 }
 
@@ -295,14 +298,14 @@ func (oe *ONNXExporter) createSigmoidNode(layerSpec layers.LayerSpec, inputTenso
 func (oe *ONNXExporter) createTanhNode(layerSpec layers.LayerSpec, inputTensor string, layerIdx int) ([]*NodeProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	tanhNode := &NodeProto{
 		OpType: "Tanh",
 		Name:   layerName,
 		Input:  []string{inputTensor},
 		Output: []string{outputTensor},
 	}
-	
+
 	return []*NodeProto{tanhNode}, outputTensor, nil
 }
 
@@ -311,7 +314,7 @@ func (oe *ONNXExporter) createSwishNode(layerSpec layers.LayerSpec, inputTensor 
 	layerName := layerSpec.Name
 	sigmoidOutput := fmt.Sprintf("%s_sigmoid", layerName)
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	// Create Sigmoid node: Sigmoid(x)
 	sigmoidNode := &NodeProto{
 		OpType: "Sigmoid",
@@ -319,7 +322,7 @@ func (oe *ONNXExporter) createSwishNode(layerSpec layers.LayerSpec, inputTensor 
 		Input:  []string{inputTensor},
 		Output: []string{sigmoidOutput},
 	}
-	
+
 	// Create Multiply node: x * Sigmoid(x)
 	multiplyNode := &NodeProto{
 		OpType: "Mul",
@@ -327,7 +330,7 @@ func (oe *ONNXExporter) createSwishNode(layerSpec layers.LayerSpec, inputTensor 
 		Input:  []string{inputTensor, sigmoidOutput},
 		Output: []string{outputTensor},
 	}
-	
+
 	return []*NodeProto{sigmoidNode, multiplyNode}, outputTensor, nil
 }
 
@@ -335,15 +338,15 @@ func (oe *ONNXExporter) createSwishNode(layerSpec layers.LayerSpec, inputTensor 
 func (oe *ONNXExporter) createBatchNormNode(layerSpec layers.LayerSpec, weightMap map[string]WeightTensor, inputTensor string, layerIdx int) ([]*NodeProto, []*TensorProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	eps := layerSpec.Parameters["eps"].(float32)
 	momentum := layerSpec.Parameters["momentum"].(float32)
 	affine := layerSpec.Parameters["affine"].(bool)
-	
+
 	if !affine {
 		return nil, nil, "", fmt.Errorf("ONNX export requires affine BatchNorm (learnable parameters)")
 	}
-	
+
 	// BatchNormalization requires: input, scale, bias, mean, var
 	batchNormNode := &NodeProto{
 		OpType: "BatchNormalization",
@@ -361,26 +364,26 @@ func (oe *ONNXExporter) createBatchNormNode(layerSpec layers.LayerSpec, weightMa
 			{Name: "momentum", F: momentum},
 		},
 	}
-	
+
 	// Create initializers
 	var initializers []*TensorProto
-	
+
 	// Scale (gamma)
 	scaleTensor := weightMap[fmt.Sprintf("%s.weight", layerName)]
 	scaleInit := oe.createTensorProto(fmt.Sprintf("%s.weight", layerName), scaleTensor.Shape, scaleTensor.Data)
 	initializers = append(initializers, scaleInit)
-	
+
 	// Bias (beta)
 	biasTensor := weightMap[fmt.Sprintf("%s.bias", layerName)]
 	biasInit := oe.createTensorProto(fmt.Sprintf("%s.bias", layerName), biasTensor.Shape, biasTensor.Data)
 	initializers = append(initializers, biasInit)
-	
+
 	// Running mean (initialize to zeros)
 	numFeatures := scaleTensor.Shape[0]
 	runningMean := make([]float32, numFeatures)
 	meanInit := oe.createTensorProto(fmt.Sprintf("%s.running_mean", layerName), []int{numFeatures}, runningMean)
 	initializers = append(initializers, meanInit)
-	
+
 	// Running variance (initialize to ones)
 	runningVar := make([]float32, numFeatures)
 	for i := range runningVar {
@@ -388,7 +391,7 @@ func (oe *ONNXExporter) createBatchNormNode(layerSpec layers.LayerSpec, weightMa
 	}
 	varInit := oe.createTensorProto(fmt.Sprintf("%s.running_var", layerName), []int{numFeatures}, runningVar)
 	initializers = append(initializers, varInit)
-	
+
 	return []*NodeProto{batchNormNode}, initializers, outputTensor, nil
 }
 
@@ -396,9 +399,9 @@ func (oe *ONNXExporter) createBatchNormNode(layerSpec layers.LayerSpec, weightMa
 func (oe *ONNXExporter) createDropoutNode(layerSpec layers.LayerSpec, inputTensor string, layerIdx int) ([]*NodeProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	rate := layerSpec.Parameters["rate"].(float32)
-	
+
 	// For inference, dropout is typically a no-op (identity)
 	// But we'll include it with the training parameter set to false
 	dropoutNode := &NodeProto{
@@ -410,7 +413,7 @@ func (oe *ONNXExporter) createDropoutNode(layerSpec layers.LayerSpec, inputTenso
 			{Name: "ratio", F: rate},
 		},
 	}
-	
+
 	return []*NodeProto{dropoutNode}, outputTensor, nil
 }
 
@@ -418,9 +421,9 @@ func (oe *ONNXExporter) createDropoutNode(layerSpec layers.LayerSpec, inputTenso
 func (oe *ONNXExporter) createSoftmaxNode(layerSpec layers.LayerSpec, inputTensor string, layerIdx int) ([]*NodeProto, string, error) {
 	layerName := layerSpec.Name
 	outputTensor := fmt.Sprintf("%s_output", layerName)
-	
+
 	axis := layerSpec.Parameters["axis"].(int)
-	
+
 	softmaxNode := &NodeProto{
 		OpType: "Softmax",
 		Name:   layerName,
@@ -430,7 +433,7 @@ func (oe *ONNXExporter) createSoftmaxNode(layerSpec layers.LayerSpec, inputTenso
 			{Name: "axis", I: int64(axis)},
 		},
 	}
-	
+
 	return []*NodeProto{softmaxNode}, outputTensor, nil
 }
 
@@ -453,7 +456,7 @@ func (oe *ONNXExporter) createTensorProto(name string, shape []int, data []float
 	for i, s := range shape {
 		dims[i] = int64(s)
 	}
-	
+
 	return &TensorProto{
 		Name:      name,
 		DataType:  TensorProto_DataType_FLOAT,
@@ -467,16 +470,16 @@ func (oe *ONNXExporter) transposeMatrix(data []float32, shape []int) []float32 {
 	if len(shape) != 2 {
 		return data // Return unchanged if not 2D
 	}
-	
+
 	rows, cols := shape[0], shape[1]
 	transposed := make([]float32, len(data))
-	
+
 	for i := 0; i < rows; i++ {
 		for j := 0; j < cols; j++ {
 			transposed[j*rows+i] = data[i*cols+j]
 		}
 	}
-	
+
 	return transposed
 }
 
@@ -495,19 +498,19 @@ func (oi *ONNXImporter) ImportFromONNX(path string) (*Checkpoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read ONNX file: %v", err)
 	}
-	
+
 	// Parse ONNX protobuf
 	var model ModelProto
 	if err := proto.Unmarshal(data, &model); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal ONNX model: %v", err)
 	}
-	
+
 	// Convert ONNX graph to go-metal model spec
 	modelSpec, weights, err := oi.convertONNXToGoMetal(&model)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert ONNX to go-metal: %v", err)
 	}
-	
+
 	// Create checkpoint
 	checkpoint := &Checkpoint{
 		ModelSpec: modelSpec,
@@ -518,32 +521,32 @@ func (oi *ONNXImporter) ImportFromONNX(path string) (*Checkpoint, error) {
 			LearningRate: 0.001, // Default
 		},
 		Metadata: CheckpointMetadata{
-			Version:   "1.0.0",
-			Framework: "go-metal",
-			CreatedAt: time.Now(),
+			Version:     "1.0.0",
+			Framework:   "go-metal",
+			CreatedAt:   time.Now(),
 			Description: fmt.Sprintf("Imported from ONNX (producer: %s)", model.ProducerName),
 		},
 	}
-	
+
 	return checkpoint, nil
 }
 
 // convertONNXToGoMetal converts ONNX graph to go-metal model specification
 func (oi *ONNXImporter) convertONNXToGoMetal(model *ModelProto) (*layers.ModelSpec, []WeightTensor, error) {
 	graph := model.Graph
-	
+
 	// Parse input shape
 	if len(graph.Input) == 0 {
 		return nil, nil, fmt.Errorf("ONNX model has no inputs")
 	}
-	
+
 	inputInfo := graph.Input[0]
 	inputShape := oi.extractShapeFromValueInfo(inputInfo)
-	
+
 	// Create weight map from initializers
 	weightMap := make(map[string][]float32)
 	shapeMap := make(map[string][]int)
-	
+
 	for _, initializer := range graph.Initializer {
 		weightMap[initializer.Name] = initializer.FloatData
 		shape := make([]int, len(initializer.Dims))
@@ -552,25 +555,25 @@ func (oi *ONNXImporter) convertONNXToGoMetal(model *ModelProto) (*layers.ModelSp
 		}
 		shapeMap[initializer.Name] = shape
 	}
-	
+
 	// Build layer specifications from ONNX nodes
 	var layerSpecs []layers.LayerSpec
 	var weights []WeightTensor
-	
+
 	// First pass: identify MatMul+Add pairs for bias absorption
 	matmulAddPairs := oi.identifyMatMulAddPairs(graph.Node)
-	
+
 	for i, node := range graph.Node {
 		// Skip Add nodes that are part of MatMul+Add pairs
 		if oi.isAddNodeInPair(node, matmulAddPairs) {
 			continue
 		}
-		
+
 		layerSpec, layerWeights, err := oi.convertONNXNodeToLayer(node, weightMap, shapeMap)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to convert ONNX node %s: %v", node.Name, err)
 		}
-		
+
 		// For MatMul nodes that are part of a pair, add the bias weight
 		if node.OpType == "MatMul" {
 			if addNode, hasBias := matmulAddPairs[i]; hasBias {
@@ -580,41 +583,41 @@ func (oi *ONNXImporter) convertONNXToGoMetal(model *ModelProto) (*layers.ModelSp
 					return nil, nil, fmt.Errorf("failed to extract bias from Add node %s: %v", addNode.Name, err)
 				}
 				layerWeights = append(layerWeights, biasWeights...)
-				
+
 				// Update layer spec to use bias
 				if layerSpec != nil {
 					layerSpec.Parameters["use_bias"] = true
 				}
 			}
 		}
-		
+
 		if layerSpec != nil {
 			layerSpecs = append(layerSpecs, *layerSpec)
 		}
 		weights = append(weights, layerWeights...)
 	}
-	
+
 	// Create model builder and compile
 	builder := layers.NewModelBuilder(inputShape)
 	for _, spec := range layerSpecs {
 		builder.AddLayer(spec)
 	}
-	
+
 	modelSpec, err := builder.Compile()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to compile imported model: %v", err)
 	}
-	
+
 	return modelSpec, weights, nil
 }
 
 // convertONNXNodeToLayer converts a single ONNX node to go-metal layer
 func (oi *ONNXImporter) convertONNXNodeToLayer(node *NodeProto, weightMap map[string][]float32, shapeMap map[string][]int) (*layers.LayerSpec, []WeightTensor, error) {
 	var weights []WeightTensor
-	
+
 	// Debug: log the operation type for troubleshooting
 	// fmt.Printf("Converting ONNX node: %s (type: %s)\n", node.Name, node.OpType)
-	
+
 	switch node.OpType {
 	case "Conv":
 		return oi.convertConvNode(node, weightMap, shapeMap, &weights)
@@ -652,17 +655,17 @@ func (oi *ONNXImporter) extractShapeFromValueInfo(info *ValueInfoProto) []int {
 	if tensorType == nil {
 		return nil
 	}
-	
+
 	shape := tensorType.Shape
 	if shape == nil {
 		return nil
 	}
-	
+
 	dims := make([]int, len(shape.Dim))
 	for i, dim := range shape.Dim {
 		dims[i] = int(dim.GetDimValue())
 	}
-	
+
 	return dims
 }
 
@@ -674,43 +677,43 @@ func (oi *ONNXImporter) convertMatMulNode(node *NodeProto, weightMap map[string]
 	if len(node.Input) < 2 {
 		return nil, nil, fmt.Errorf("MatMul node %s: expected 2 inputs [X, W], got %d", node.Name, len(node.Input))
 	}
-	
+
 	weightName := node.Input[1]
 	weightData, exists := weightMap[weightName]
 	if !exists {
 		return nil, nil, fmt.Errorf("MatMul node %s: weight tensor %s not found", node.Name, weightName)
 	}
-	
+
 	weightShape, exists := shapeMap[weightName]
 	if !exists {
 		return nil, nil, fmt.Errorf("MatMul node %s: weight shape for %s not found", node.Name, weightName)
 	}
-	
-	// Validate weight shape 
+
+	// Validate weight shape
 	if len(weightShape) != 2 {
 		return nil, nil, fmt.Errorf("MatMul node %s: weight tensor must be 2D, got shape %v", node.Name, weightShape)
 	}
-	
+
 	// ONNX MatMul weight format analysis:
 	// Based on the shapes we see: [32, 32768] and [2, 32]
 	// This suggests ONNX stores weights as [output_size, input_size]
 	// But go-metal expects [input_size, output_size]
 	// We need to transpose the interpretation
-	outputSize := weightShape[0]  
-	inputSize := weightShape[1]   
-	
-	// Debug: log weight shape for troubleshooting  
-	// fmt.Printf("MatMul node %s: weight shape %v -> input_size=%d, output_size=%d (transposed interpretation)\n", 
+	outputSize := weightShape[0]
+	inputSize := weightShape[1]
+
+	// Debug: log weight shape for troubleshooting
+	// fmt.Printf("MatMul node %s: weight shape %v -> input_size=%d, output_size=%d (transposed interpretation)\n",
 	//	node.Name, weightShape, inputSize, outputSize)
-	
+
 	var layerWeights []WeightTensor
-	
+
 	// Create weight tensor (GPU-resident principle)
 	// Note: ONNX uses [output, input] but go-metal expects [input, output]
 	// We need to transpose both the shape and the data
 	transposedShape := []int{inputSize, outputSize}
 	transposedData := transposeMatrix2D(weightData, weightShape[0], weightShape[1])
-	
+
 	weightTensor := WeightTensor{
 		Name:  fmt.Sprintf("%s.weight", node.Name),
 		Shape: transposedShape,
@@ -719,7 +722,7 @@ func (oi *ONNXImporter) convertMatMulNode(node *NodeProto, weightMap map[string]
 		Type:  "weight",
 	}
 	layerWeights = append(layerWeights, weightTensor)
-	
+
 	// Create go-metal Dense layer specification
 	// Note: useBias=false for pure MatMul, bias handled by subsequent Add node
 	layerSpec := &layers.LayerSpec{
@@ -731,7 +734,7 @@ func (oi *ONNXImporter) convertMatMulNode(node *NodeProto, weightMap map[string]
 			"use_bias":    false, // Pure MatMul, bias added separately via Add node
 		},
 	}
-	
+
 	return layerSpec, layerWeights, nil
 }
 
@@ -740,7 +743,7 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 	var kernelShape []int64
 	var strides []int64
 	var pads []int64
-	
+
 	for _, attr := range node.Attribute {
 		switch attr.Name {
 		case "kernel_shape":
@@ -751,7 +754,7 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 			pads = attr.Ints
 		}
 	}
-	
+
 	// Validate Conv parameters
 	if len(kernelShape) != 2 {
 		return nil, nil, fmt.Errorf("Conv node %s: only 2D convolutions supported, got kernel_shape %v", node.Name, kernelShape)
@@ -762,12 +765,12 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 	if len(pads) != 4 {
 		return nil, nil, fmt.Errorf("Conv node %s: pads must be [top, left, bottom, right], got %v", node.Name, pads)
 	}
-	
+
 	// Validate uniform padding (go-metal supports uniform padding only)
 	if pads[0] != pads[1] || pads[1] != pads[2] || pads[2] != pads[3] {
 		return nil, nil, fmt.Errorf("Conv node %s: only uniform padding supported, got %v", node.Name, pads)
 	}
-	
+
 	// Validate square kernels and uniform strides
 	if kernelShape[0] != kernelShape[1] {
 		return nil, nil, fmt.Errorf("Conv node %s: only square kernels supported, got %v", node.Name, kernelShape)
@@ -775,43 +778,43 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 	if strides[0] != strides[1] {
 		return nil, nil, fmt.Errorf("Conv node %s: only uniform strides supported, got %v", node.Name, strides)
 	}
-	
+
 	// Extract weight tensor (ONNX format: [output_channels, input_channels, kernel_h, kernel_w])
 	if len(node.Input) < 2 {
 		return nil, nil, fmt.Errorf("Conv node %s: expected at least 2 inputs (input, weight), got %d", node.Name, len(node.Input))
 	}
-	
+
 	weightName := node.Input[1]
 	weightData, exists := weightMap[weightName]
 	if !exists {
 		return nil, nil, fmt.Errorf("Conv node %s: weight tensor %s not found", node.Name, weightName)
 	}
-	
+
 	weightShape, exists := shapeMap[weightName]
 	if !exists {
 		return nil, nil, fmt.Errorf("Conv node %s: weight shape for %s not found", node.Name, weightName)
 	}
-	
+
 	// Validate weight shape [out_channels, in_channels, kernel_h, kernel_w]
 	if len(weightShape) != 4 {
 		return nil, nil, fmt.Errorf("Conv node %s: weight tensor must be 4D, got shape %v", node.Name, weightShape)
 	}
-	
+
 	outputChannels := weightShape[0]
 	inputChannels := weightShape[1]
 	kernelH := weightShape[2]
 	kernelW := weightShape[3]
-	
+
 	// Validate kernel dimensions match attributes
 	if int64(kernelH) != kernelShape[0] || int64(kernelW) != kernelShape[1] {
-		return nil, nil, fmt.Errorf("Conv node %s: kernel shape mismatch: weight %dx%d vs attribute %v", 
+		return nil, nil, fmt.Errorf("Conv node %s: kernel shape mismatch: weight %dx%d vs attribute %v",
 			node.Name, kernelH, kernelW, kernelShape)
 	}
-	
+
 	// Check for bias (optional third input)
 	useBias := len(node.Input) >= 3
 	var layerWeights []WeightTensor
-	
+
 	// Create weight tensor (GPU-resident principle - data stays as-is, will be copied to GPU)
 	weightTensor := WeightTensor{
 		Name:  fmt.Sprintf("%s.weight", node.Name),
@@ -821,7 +824,7 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 		Type:  "weight",
 	}
 	layerWeights = append(layerWeights, weightTensor)
-	
+
 	// Handle bias if present
 	if useBias {
 		biasName := node.Input[2]
@@ -829,18 +832,18 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 		if !exists {
 			return nil, nil, fmt.Errorf("Conv node %s: bias tensor %s not found", node.Name, biasName)
 		}
-		
+
 		biasShape, exists := shapeMap[biasName]
 		if !exists {
 			return nil, nil, fmt.Errorf("Conv node %s: bias shape for %s not found", node.Name, biasName)
 		}
-		
+
 		// Validate bias shape [output_channels]
 		if len(biasShape) != 1 || biasShape[0] != outputChannels {
-			return nil, nil, fmt.Errorf("Conv node %s: bias shape must be [%d], got %v", 
+			return nil, nil, fmt.Errorf("Conv node %s: bias shape must be [%d], got %v",
 				node.Name, outputChannels, biasShape)
 		}
-		
+
 		biasTensor := WeightTensor{
 			Name:  fmt.Sprintf("%s.bias", node.Name),
 			Shape: biasShape,
@@ -850,7 +853,7 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 		}
 		layerWeights = append(layerWeights, biasTensor)
 	}
-	
+
 	// Create go-metal Conv2D layer specification (adhering to layer factory design)
 	layerSpec := &layers.LayerSpec{
 		Type: layers.Conv2D,
@@ -864,7 +867,7 @@ func (oi *ONNXImporter) convertConvNode(node *NodeProto, weightMap map[string][]
 			"use_bias":        useBias,
 		},
 	}
-	
+
 	return layerSpec, layerWeights, nil
 }
 
@@ -872,10 +875,10 @@ func (oi *ONNXImporter) convertAddNode(node *NodeProto, weightMap map[string][]f
 	// Add nodes in ONNX are typically used for bias addition in Dense layers
 	// In go-metal, bias is handled as part of the Dense layer itself
 	// So we don't create a separate layer for Add - it's absorbed into Dense layer
-	
+
 	// This means Add nodes are processed during Dense layer construction
 	// and don't generate standalone layers in go-metal architecture
-	
+
 	// Return nil to indicate this node doesn't create a layer
 	// (GPU-resident principle: minimize separate operations, fuse into Dense layer)
 	return nil, nil, nil
@@ -896,7 +899,7 @@ func (oi *ONNXImporter) convertLeakyReluNode(node *NodeProto) *layers.LayerSpec 
 			alpha = attr.F
 		}
 	}
-	
+
 	return &layers.LayerSpec{
 		Type: layers.LeakyReLU,
 		Name: node.Name,
@@ -925,16 +928,16 @@ func (oi *ONNXImporter) convertTanhNode(node *NodeProto) *layers.LayerSpec {
 func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[string][]float32, shapeMap map[string][]int, weights *[]WeightTensor) (*layers.LayerSpec, []WeightTensor, error) {
 	// ONNX BatchNormalization inputs: [X, scale, B, input_mean, input_var]
 	// where X=input, scale=gamma, B=beta, input_mean=running_mean, input_var=running_var
-	
+
 	if len(node.Input) < 5 {
-		return nil, nil, fmt.Errorf("BatchNorm node %s: expected 5 inputs [X, scale, B, mean, var], got %d", 
+		return nil, nil, fmt.Errorf("BatchNorm node %s: expected 5 inputs [X, scale, B, mean, var], got %d",
 			node.Name, len(node.Input))
 	}
-	
+
 	// Extract BatchNorm attributes
 	epsilon := float32(1e-5) // Default epsilon
 	momentum := float32(0.9) // Default momentum
-	
+
 	for _, attr := range node.Attribute {
 		switch attr.Name {
 		case "epsilon":
@@ -943,15 +946,15 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 			momentum = attr.F
 		}
 	}
-	
+
 	// Extract weight tensors
-	scaleName := node.Input[1]    // gamma (scale parameter)
-	biasName := node.Input[2]     // beta (bias parameter)
-	meanName := node.Input[3]     // running mean
-	varName := node.Input[4]      // running variance
-	
+	scaleName := node.Input[1] // gamma (scale parameter)
+	biasName := node.Input[2]  // beta (bias parameter)
+	meanName := node.Input[3]  // running mean
+	varName := node.Input[4]   // running variance
+
 	var layerWeights []WeightTensor
-	
+
 	// Validate and extract scale (gamma) tensor
 	scaleData, exists := weightMap[scaleName]
 	if !exists {
@@ -961,13 +964,13 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 	if !exists {
 		return nil, nil, fmt.Errorf("BatchNorm node %s: scale shape for %s not found", node.Name, scaleName)
 	}
-	
+
 	// Validate scale shape [num_features]
 	if len(scaleShape) != 1 {
 		return nil, nil, fmt.Errorf("BatchNorm node %s: scale tensor must be 1D, got shape %v", node.Name, scaleShape)
 	}
 	numFeatures := scaleShape[0]
-	
+
 	// Create gamma (scale) tensor - use .weight naming for compatibility
 	gammaTensor := WeightTensor{
 		Name:  fmt.Sprintf("%s.weight", node.Name),
@@ -977,7 +980,7 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 		Type:  "weight",
 	}
 	layerWeights = append(layerWeights, gammaTensor)
-	
+
 	// Extract and validate bias (beta) tensor
 	biasData, exists := weightMap[biasName]
 	if !exists {
@@ -987,13 +990,13 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 	if !exists {
 		return nil, nil, fmt.Errorf("BatchNorm node %s: bias shape for %s not found", node.Name, biasName)
 	}
-	
+
 	// Validate bias shape matches scale
 	if len(biasShape) != 1 || biasShape[0] != numFeatures {
-		return nil, nil, fmt.Errorf("BatchNorm node %s: bias shape must be [%d], got %v", 
+		return nil, nil, fmt.Errorf("BatchNorm node %s: bias shape must be [%d], got %v",
 			node.Name, numFeatures, biasShape)
 	}
-	
+
 	// Create beta (bias) tensor - use .bias naming for compatibility
 	betaTensor := WeightTensor{
 		Name:  fmt.Sprintf("%s.bias", node.Name),
@@ -1003,7 +1006,7 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 		Type:  "bias",
 	}
 	layerWeights = append(layerWeights, betaTensor)
-	
+
 	// Validate that running mean tensor exists and has correct shape
 	_, exists = weightMap[meanName]
 	if !exists {
@@ -1013,19 +1016,19 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 	if !exists {
 		return nil, nil, fmt.Errorf("BatchNorm node %s: mean shape for %s not found", node.Name, meanName)
 	}
-	
+
 	// Validate mean shape
 	if len(meanShape) != 1 || meanShape[0] != numFeatures {
-		return nil, nil, fmt.Errorf("BatchNorm node %s: mean shape must be [%d], got %v", 
+		return nil, nil, fmt.Errorf("BatchNorm node %s: mean shape must be [%d], got %v",
 			node.Name, numFeatures, meanShape)
 	}
-	
+
 	// Note: For inference mode, running_mean and running_var are typically
 	// not loaded as separate weight tensors but are used to pre-compute
 	// the normalization parameters and fold them into the weight and bias.
 	// However, for compatibility with the go-metal engine, we include them
 	// as separate tensors but don't count them toward the parameter count.
-	
+
 	// UNIFIED SOLUTION: Extract running mean and variance data for inference mode
 	// These will be fed to BatchNorm placeholders during inference execution
 	runningMeanData, exists := weightMap[meanName]
@@ -1036,7 +1039,7 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 	if !exists {
 		return nil, nil, fmt.Errorf("BatchNorm node %s: variance tensor %s not found", node.Name, varName)
 	}
-	
+
 	// Create running statistics tensors - these are NOT counted as learnable parameters
 	// but are needed to feed the BatchNorm placeholders during inference
 	runningMeanTensor := WeightTensor{
@@ -1053,23 +1056,23 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 		Layer: node.Name,
 		Type:  "running_var",
 	}
-	
+
 	// Add running statistics to layer weights (they will be handled separately from learnable parameters)
 	layerWeights = append(layerWeights, runningMeanTensor)
 	layerWeights = append(layerWeights, runningVarTensor)
-	
-	// Create go-metal BatchNorm layer specification 
+
+	// Create go-metal BatchNorm layer specification
 	// (MPSGraph-centric: will use MPSGraph batch normalization operations)
 	layerSpec := &layers.LayerSpec{
 		Type: layers.BatchNorm,
 		Name: node.Name,
 		Parameters: map[string]interface{}{
-			"num_features": numFeatures,
-			"epsilon":      epsilon,
-			"momentum":     momentum,
-			"affine":       true,  // Always true since we have gamma and beta
-			"track_running_stats": true, // Always true since we have running stats
-			"training":     false, // INFERENCE MODE: Use pre-trained running stats, not batch stats
+			"num_features":        numFeatures,
+			"epsilon":             epsilon,
+			"momentum":            momentum,
+			"affine":              true,  // Always true since we have gamma and beta
+			"track_running_stats": true,  // Always true since we have running stats
+			"training":            false, // INFERENCE MODE: Use pre-trained running stats, not batch stats
 		},
 		// ARCHITECTURAL FIX: Embed running statistics in LayerSpec for graph construction
 		RunningStatistics: map[string][]float32{
@@ -1077,7 +1080,7 @@ func (oi *ONNXImporter) convertBatchNormNode(node *NodeProto, weightMap map[stri
 			"running_var":  runningVarData,
 		},
 	}
-	
+
 	return layerSpec, layerWeights, nil
 }
 
@@ -1088,7 +1091,7 @@ func (oi *ONNXImporter) convertDropoutNode(node *NodeProto) *layers.LayerSpec {
 			rate = attr.F
 		}
 	}
-	
+
 	return &layers.LayerSpec{
 		Type: layers.Dropout,
 		Name: node.Name,
@@ -1106,7 +1109,7 @@ func (oi *ONNXImporter) convertSoftmaxNode(node *NodeProto) *layers.LayerSpec {
 			axis = int(attr.I)
 		}
 	}
-	
+
 	return &layers.LayerSpec{
 		Type: layers.Softmax,
 		Name: node.Name,
@@ -1121,10 +1124,10 @@ func (oi *ONNXImporter) convertFlattenNode(node *NodeProto) *layers.LayerSpec {
 	// In go-metal, flattening is handled automatically by Dense layers
 	// when they receive higher-dimensional input (like 4D from Conv2D)
 	// So Flatten operations don't need to create actual layers
-	// 
+	//
 	// GPU-resident principle: minimize operations by fusing Flatten into Dense layer
 	// MPSGraph-centric: let MPSGraph handle tensor reshaping automatically
-	
+
 	// Return nil to indicate this operation doesn't generate a standalone layer
 	return nil
 }
@@ -1132,22 +1135,22 @@ func (oi *ONNXImporter) convertFlattenNode(node *NodeProto) *layers.LayerSpec {
 // transposeMatrix2D transposes a 2D matrix stored as 1D array
 func transposeMatrix2D(data []float32, rows, cols int) []float32 {
 	transposed := make([]float32, len(data))
-	
+
 	for i := 0; i < rows; i++ {
 		for j := 0; j < cols; j++ {
-			// Original: data[i*cols + j] 
+			// Original: data[i*cols + j]
 			// Transposed: transposed[j*rows + i]
 			transposed[j*rows+i] = data[i*cols+j]
 		}
 	}
-	
+
 	return transposed
 }
 
 // identifyMatMulAddPairs identifies MatMul+Add pairs for bias absorption
 func (oi *ONNXImporter) identifyMatMulAddPairs(nodes []*NodeProto) map[int]*NodeProto {
 	pairs := make(map[int]*NodeProto)
-	
+
 	for i, node := range nodes {
 		if node.OpType == "MatMul" && i+1 < len(nodes) {
 			nextNode := nodes[i+1]
@@ -1161,7 +1164,7 @@ func (oi *ONNXImporter) identifyMatMulAddPairs(nodes []*NodeProto) map[int]*Node
 			}
 		}
 	}
-	
+
 	return pairs
 }
 
@@ -1170,37 +1173,37 @@ func (oi *ONNXImporter) isAddNodeInPair(node *NodeProto, pairs map[int]*NodeProt
 	if node.OpType != "Add" {
 		return false
 	}
-	
+
 	for _, addNode := range pairs {
 		if addNode.Name == node.Name {
 			return true
 		}
 	}
-	
+
 	return false
 }
 
 // extractBiasFromAddNode extracts bias weights from an Add node
 func (oi *ONNXImporter) extractBiasFromAddNode(addNode *NodeProto, weightMap map[string][]float32, shapeMap map[string][]int, matmulName string) ([]WeightTensor, error) {
 	var biasWeights []WeightTensor
-	
+
 	// Add node should have 2 inputs: [matmul_output, bias_tensor]
 	if len(addNode.Input) < 2 {
 		return nil, fmt.Errorf("Add node %s: expected 2 inputs, got %d", addNode.Name, len(addNode.Input))
 	}
-	
+
 	// The bias tensor is the second input
 	biasName := addNode.Input[1]
 	biasData, exists := weightMap[biasName]
 	if !exists {
 		return nil, fmt.Errorf("Add node %s: bias tensor %s not found", addNode.Name, biasName)
 	}
-	
+
 	biasShape, exists := shapeMap[biasName]
 	if !exists {
 		return nil, fmt.Errorf("Add node %s: bias shape for %s not found", addNode.Name, biasName)
 	}
-	
+
 	// Create bias tensor with MatMul layer name
 	biasTensor := WeightTensor{
 		Name:  fmt.Sprintf("%s.bias", matmulName),
@@ -1210,6 +1213,6 @@ func (oi *ONNXImporter) extractBiasFromAddNode(addNode *NodeProto, weightMap map
 		Type:  "bias",
 	}
 	biasWeights = append(biasWeights, biasTensor)
-	
+
 	return biasWeights, nil
 }

--- a/checkpoints/running_stats.go
+++ b/checkpoints/running_stats.go
@@ -1,0 +1,33 @@
+package checkpoints
+
+// generateIntelligentRunningStats creates reasonable running statistics for BatchNorm layers.
+// It checks for existing statistics and falls back to mean=0 and var=1 defaults.
+func generateIntelligentRunningStats(layerName string, numFeatures int, runningStats map[string][]float32) ([]float32, []float32) {
+	runningMean := make([]float32, numFeatures)
+	runningVar := make([]float32, numFeatures)
+
+	if runningStats != nil {
+		if existingMean, ok := runningStats["running_mean"]; ok && len(existingMean) == numFeatures {
+			copy(runningMean, existingMean)
+		} else {
+			for i := range runningMean {
+				runningMean[i] = 0
+			}
+		}
+		if existingVar, ok := runningStats["running_var"]; ok && len(existingVar) == numFeatures {
+			copy(runningVar, existingVar)
+		} else {
+			for i := range runningVar {
+				runningVar[i] = 1
+			}
+		}
+	} else {
+		// No existing statistics - use defaults
+		for i := 0; i < numFeatures; i++ {
+			runningMean[i] = 0
+			runningVar[i] = 1
+		}
+	}
+
+	return runningMean, runningVar
+}

--- a/checkpoints/running_stats_test.go
+++ b/checkpoints/running_stats_test.go
@@ -1,0 +1,53 @@
+package checkpoints
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestGenerateIntelligentRunningStats verifies running statistics generation.
+func TestGenerateIntelligentRunningStats(t *testing.T) {
+	layerName := "bn1"
+	numFeatures := 3
+
+	// Case 1: No existing running statistics -> defaults
+	mean, variance := generateIntelligentRunningStats(layerName, numFeatures, nil)
+	expectMean := []float32{0, 0, 0}
+	expectVar := []float32{1, 1, 1}
+	if !reflect.DeepEqual(mean, expectMean) {
+		t.Fatalf("expected mean %v, got %v", expectMean, mean)
+	}
+	if !reflect.DeepEqual(variance, expectVar) {
+		t.Fatalf("expected var %v, got %v", expectVar, variance)
+	}
+
+	// Case 2: Existing statistics with correct length -> copy values
+	stats := map[string][]float32{
+		"running_mean": {1.0, 2.0, 3.0},
+		"running_var":  {0.5, 0.6, 0.7},
+	}
+	mean, variance = generateIntelligentRunningStats(layerName, numFeatures, stats)
+	expectMean = []float32{1.0, 2.0, 3.0}
+	expectVar = []float32{0.5, 0.6, 0.7}
+	if !reflect.DeepEqual(mean, expectMean) {
+		t.Fatalf("expected mean %v, got %v", expectMean, mean)
+	}
+	if !reflect.DeepEqual(variance, expectVar) {
+		t.Fatalf("expected var %v, got %v", expectVar, variance)
+	}
+
+	// Case 3: Existing statistics with wrong length -> defaults
+	stats = map[string][]float32{
+		"running_mean": {1.0},
+		"running_var":  {0.5},
+	}
+	mean, variance = generateIntelligentRunningStats(layerName, numFeatures, stats)
+	expectMean = []float32{0, 0, 0}
+	expectVar = []float32{1, 1, 1}
+	if !reflect.DeepEqual(mean, expectMean) {
+		t.Fatalf("expected mean %v, got %v", expectMean, mean)
+	}
+	if !reflect.DeepEqual(variance, expectVar) {
+		t.Fatalf("expected var %v, got %v", expectVar, variance)
+	}
+}


### PR DESCRIPTION
## Summary
- add cgo_bridge stub so non-darwin builds skip metal bindings
- refactor running stats helper into pure Go and update tests
- document Linux test workflow using `CGO_ENABLED=0 go test ./checkpoints`

## Testing
- `CGO_ENABLED=0 go vet ./checkpoints`
- `CGO_ENABLED=0 go test ./checkpoints -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1ecb4dc832e9d257d65d9ad316e